### PR TITLE
FIX: don't create a slice from a map

### DIFF
--- a/wavefront/resource_dashboard.go
+++ b/wavefront/resource_dashboard.go
@@ -2,7 +2,6 @@ package wavefront_plugin
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -1015,14 +1014,6 @@ func resourceDashboardCreate(d *schema.ResourceData, m interface{}) error {
 	return resourceDashboardRead(d, m)
 }
 
-type Params []map[string]interface{}
-
-func (p Params) Len() int      { return len(p) }
-func (p Params) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-func (p Params) Less(i, j int) bool {
-	return sort.StringsAreSorted([]string{p[i]["name"].(string), p[j]["name"].(string)})
-}
-
 // Read a Wavefront Dashboard
 func resourceDashboardRead(d *schema.ResourceData, m interface{}) error {
 	dashboards := m.(*wavefrontClient).client.Dashboards()
@@ -1055,15 +1046,7 @@ func resourceDashboardRead(d *schema.ResourceData, m interface{}) error {
 	}
 	d.Set("section", sections)
 
-	parameterDetails := []map[string]interface{}{}
-
-	for k, v := range dash.ParameterDetails {
-		parameterDetails = append(parameterDetails, buildTerraformParameterDetail(v, k))
-	}
-
-	sort.Sort(Params(parameterDetails))
-
-	d.Set("parameter_details", parameterDetails)
+	d.Set("parameter_details", dash.ParameterDetails)
 	d.Set("tags", dash.Tags)
 
 	return nil


### PR DESCRIPTION
This PR fixes an issue where terraform thinks there are changes when there aren't.

Looking through all the use cases in this repo and testing locally I don't see any reason why this was done in the first place...